### PR TITLE
Add github build & release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build plugin
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  gradle-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v3
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Run build with Gradle Wrapper
+        run: ./gradlew build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: KarmaSMP
+          path: build/libs
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: build/libs
+          generate_release_notes: true
+          append_body: true

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ tasks.runServer {
     minecraftVersion("1.20.2")
 }
 
+tasks.assemble {
+    dependsOn(reobfJar)
+}
+
 tasks.withType(JavaCompile).configureEach {
     if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
         options.release = targetJavaVersion


### PR DESCRIPTION
Automates plugin build and will automatically create releases for tags starting with `v`.

To create a new release, just go and create a new release on GitHub with a tag starting with `v`, fill in relevant information and the action _should_ update it with artifacts and append automatic release notes. (Will test this with a v0.0.0 release once merged)